### PR TITLE
create MdsWindow only once app.isReady()

### DIFF
--- a/coffee/main.coffee
+++ b/coffee/main.coffee
@@ -37,7 +37,7 @@ app.on 'before-quit', ->
   MdsWindow.appWillQuit = true
 
 app.on 'activate', (e, hasVisibleWindows) ->
-  new MdsWindow unless hasVisibleWindows
+  new MdsWindow if app.isReady() and not hasVisibleWindows
 
 app.on 'open-file', (e, path) ->
   e.preventDefault()


### PR DESCRIPTION
I wasn't able to reproduce #11, since it does appear to be a race condition. However, this appears to be a common issue with apps built on top of Electron.

`MdsWindow` creates a `new BrowserWindow`, but you're only allowed to do that once your `app` has fired a `'ready'` event.