### PR TITLE
Implement "Reopen with Encoding" command in File menu

### DIFF
--- a/coffee/classes/mds_main_menu.coffee
+++ b/coffee/classes/mds_main_menu.coffee
@@ -98,6 +98,11 @@ module.exports = class MdsMainMenu
               label: 'Open &Recent'
               submenu: [{ replacement: 'fileHistory' }]
             }
+            {
+              label: 'Reopen with Encoding'
+              enabled: !!@window?.mdsWindow?.path
+              submenu: [{ replacement: 'encodings' }]
+            }
             { label: '&Save', enabled: @window?, accelerator: 'CmdOrCtrl+S', click: => @window.mdsWindow.trigger 'save' }
             { label: 'Save &As...', enabled: @window?, click: => @window.mdsWindow.trigger 'saveAs' }
             { type: 'separator' }
@@ -181,7 +186,7 @@ module.exports = class MdsMainMenu
                   click: (item, w) ->
                     MdsWindow.loadFromFile(
                       path.join(__dirname, '../../example.md'),
-                      w?.mdsWindow, true
+                      w?.mdsWindow, { ignoreRecent: true }
                     )
                 }
                 { type: 'separator' }
@@ -190,7 +195,7 @@ module.exports = class MdsMainMenu
                   click: (item, w) ->
                     MdsWindow.loadFromFile(
                       path.join(__dirname, '../../examples/gaia.md'),
-                      w?.mdsWindow, true
+                      w?.mdsWindow, { ignoreRecent: true }
                     )
                 }
               ]
@@ -262,5 +267,133 @@ module.exports = class MdsMainMenu
               click: => @window.mdsWindow.send 'setTheme', 'gaia' unless @window.mdsWindow.freeze
             }
           ]
+
+          encodings: do =>
+            injectAll = (items) =>
+              inject = (item) =>
+                item.enabled = !!@window?.mdsWindow?.path
+
+                if item.encoding?
+                  item.click = => @window.mdsWindow.trigger 'reopen', { encoding: item.encoding }
+
+                injectAll(item.submenu) if item.submenu?
+                item
+
+              inject(i) for i in items
+
+            injectAll [
+              { label: 'UTF-8 (Default)', encoding: 'utf8' }
+              { label: 'UTF-16LE', encoding: 'utf16le' }
+              { label: 'UTF-16BE', encoding: 'utf16be' }
+              { type: 'separator' }
+              {
+                label: 'Western'
+                submenu: [
+                  { label: 'Windows 1252', encoding: 'windows1252' }
+                  { label: 'ISO 8859-1', encoding: 'iso88591' }
+                  { label: 'ISO 8859-3', encoding: 'iso88593' }
+                  { label: 'ISO 8859-15', encoding: 'iso885915' }
+                  { label: 'Mac Roman', encoding: 'macroman' }
+                ]
+              }
+              {
+                label: 'Arabic'
+                submenu: [
+                  { label: 'Windows 1256', encoding: 'windows1256' }
+                  { label: 'ISO 8859-6', encoding: 'iso88596' }
+                ]
+              }
+              {
+                label: 'Baltic'
+                submenu: [
+                  { label: 'Windows 1257', encoding: 'windows1257' }
+                  { label: 'ISO 8859-4', encoding: 'iso88594' }
+                ]
+              }
+              {
+                label: 'Celtic'
+                submenu: [{ label: 'ISO 8859-14', encoding: 'iso885914' }]
+              }
+              {
+                label: 'Central European'
+                submenu: [
+                  { label: 'Windows 1250', encoding: 'windows1250' }
+                  { label: 'ISO 8859-2', encoding: 'iso88592' }
+                ]
+              }
+              {
+                label: 'Cyrillic'
+                submenu: [
+                  { label: 'Windows 1251', encoding: 'windows1251' }
+                  { label: 'CP 866', encoding: 'cp866' }
+                  { label: 'ISO 8859-5', encoding: 'iso88595' }
+                  { label: 'KOI8-R', encoding: 'koi8r' }
+                  { label: 'KOI8-U', encoding: 'koi8u' }
+                ]
+              }
+              {
+                label: 'Estonian'
+                submenu: [{ label: 'ISO 8859-13', encoding: 'iso885913' }]
+              }
+              {
+                label: 'Greek'
+                submenu: [
+                  { label: 'Windows 1253', encoding: 'windows1253' }
+                  { label: 'ISO 8859-7', encoding: 'iso88597' }
+                ]
+              }
+              {
+                label: 'Hebrew'
+                submenu: [
+                  { label: 'Windows 1255', encoding: 'windows1255' }
+                  { label: 'ISO 8859-8', encoding: 'iso88598' }
+                ]
+              }
+              {
+                label: 'Nordic'
+                submenu: [{ label: 'ISO 8859-10', encoding: 'iso885910' }]
+              }
+              {
+                label: 'Romanian'
+                submenu: [{ label: 'ISO 8859-16', encoding: 'iso885916' }]
+              }
+              {
+                label: 'Turkish'
+                submenu: [
+                  { label: 'Windows 1254', encoding: 'windows1254' }
+                  { label: 'ISO 8859-9', encoding: 'iso88599' }
+                ]
+              }
+              {
+                label: 'Vietnamese'
+                submenu: [{ label: 'Windows 1254', encoding: 'windows1258' }]
+              }
+              {
+                label: 'Chinese'
+                submenu: [
+                  { label: 'GBK', encoding: 'gbk' }
+                  { label: 'GB18030', encoding: 'gb18030' }
+                  { type: 'separator' }
+                  { label: 'Big5', encoding: 'cp950' }
+                  { label: 'Big5-HKSCS', encoding: 'big5hkscs' }
+                ]
+              }
+              {
+                label: 'Japanese'
+                submenu: [
+                  { label: 'Shift JIS', encoding: 'shiftjis' }
+                  { label: 'EUC-JP', encoding: 'eucjp' }
+                  { label: 'CP 932', encoding: 'cp932' }
+                ]
+              }
+              {
+                label: 'Korean'
+                submenu: [{ label: 'EUC-KR', encoding: 'euckr' }]
+              }
+              {
+                label: 'Other'
+                submenu: [{ label: 'CP 437 (DOS)', encoding: 'cp437' }]
+              }
+            ]
 
     @applyMenu()


### PR DESCRIPTION
It has mentioned in #22. I added `Reopen with Encoding` command to `File` menu.

- `Reopen with Encoding` is disabled in new document, and it's enabled in existed file.
- When you click menu-item of the encoding, an opened file will re-open from disk.
- If you have edited buffer, Marp asks whether re-opening.

Implemented encoding which have organized menu-items by country groups are based on [atom/encoding-selector](https://github.com/atom/encoding-selector/blob/master/lib/main.coffee).

### Screen cast

![marp](https://cloud.githubusercontent.com/assets/3993388/17079167/ceb4a0ce-5142-11e6-909a-29e654c40c27.gif)
