### PR TITLE
Improve licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,13 +2,10 @@ The MIT License (MIT)
 
 Copyright (c) 2016 Yuki Hattori (yukihattori1116@gmail.com)
 
-This software also uses portions of the KaTeX and underscore.js projects, which are
-MIT licensed with the following copyrights:
+This software also uses portions of the KaTeX projects, which are MIT
+licensed with the following copyrights:
 
 KaTeX Copyright (c) 2015 Khan Academy
-
-underscore.js Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
-Reporters & Editors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -107,6 +107,7 @@ gulp.task 'dist', ['clean:dist'], ->
     '*.html'
     'package.json'
     'example.md'
+    'LICENSE'
   ], { base: '.' })
     .pipe gulp.dest('dist')
     .pipe $.install


### PR DESCRIPTION
#### `LICENSE` file

In fact Marp is not using [underscore.js](http://underscorejs.org/) and not including its resource. I have removed the mention of it.

#### `gulpfile.coffee`

The future version of Marp will include resource of external library to published packages. So I think it including LICENSE file is more better.

----

#### More details about licence...

##### As a Marp repository (source code)

Because Marp repository certainly includes KaTeX resources (Fonts), there is still KaTeX's copyright on `LICENSES`.

On the other hand, the [underscore.js](http://underscorejs.org/underscore-min.js) can't find anywhere in Marp repository. It managed by developer's `npm`.

On the point of view of source code management, Marp have not owned source code of underscore.js. So I think it should not have license of non-owned code.

##### As a Marp binary (release package)

Of course Marp requires `markdown-it-katex` when executing it ([and it requires `katex`](https://github.com/waylonflinn/markdown-it-katex/blob/master/package.json)).

Any developer install required libraries by using `npm install`. And `npm` is put them on `./node_modules`. Then there will be KaTeX's license in [`node_modules/katex/LICENSE.txt`](https://github.com/Khan/KaTeX/blob/master/LICENSE.txt).

It is same in building release packages: `gulp release`. Packages will include `node_modules/katex/LICENSE.txt` with packed by [asar](https://github.com/electron/asar).

Now, KaTeX's license file includes the mention of underscore.js. If we had underscore.js as a part of Marp's `LICENSE`, its license would have duplicated. So I removed the mention to underscore.js from `LICENSE`.

##### Similar cases

This approach is like #62 (already merged). He had put `twemoji`'s emoji images as Marp's resource for rendering emoji in offline.

And he had put [`LICENSE-GRAPHICS`](https://github.com/twitter/twemoji/blob/gh-pages/LICENSE-GRAPHICS) from `twemoji` because emoji images are licensed by [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/) and are managed in Marp repository. But [license of `twemoji` library](https://github.com/twitter/twemoji/blob/gh-pages/LICENSE) (MIT) hadn't because it will required by `npm install` through `package.json`.