### PR TITLE
Fix lang attribute of the slides html

### DIFF
--- a/slide.html
+++ b/slide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <title>Marp presentation</title>


### PR DESCRIPTION
should default using en, because the lang attribute will affect the punctuation of Fonts