### PR TITLE
Read editor font family and font size from config not CSS

### DIFF
--- a/coffee/classes/mds_config.coffee
+++ b/coffee/classes/mds_config.coffee
@@ -10,6 +10,9 @@ class MdsConfig
   configFile: Path.join(app.getPath('userData'), 'config.json')
 
   @initialConfig:
+    editor:
+      fontFamily: 'Osaka-mono, "MS Gothic", monospace'
+      fontSize: '14px'
     fileHistory: []
     fileHistoryMax: 8
     splitterPosition: 0.5

--- a/coffee/classes/mds_window.coffee
+++ b/coffee/classes/mds_window.coffee
@@ -66,6 +66,7 @@ module.exports = class MdsWindow
       bw.webContents.on 'did-finish-load', =>
         @_windowLoaded = true
         @send 'setSplitter', global.marp.config.get('splitterPosition')
+        @send 'setEditorConfig', global.marp.config.get('editor')
         @trigger 'load', fileOpts?.buffer || '', @path
 
       bw.once 'ready-to-show', => bw.show()

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -175,6 +175,11 @@ do ->
 
     return splitPoint
 
+  setEditorConfig = (editorConfig) ->
+    editor = $(editorStates.codeMirror?.getWrapperElement())
+    editor.css('font-family', editorConfig.fontFamily) if editor?
+    editor.css('font-size', editorConfig.fontSize) if editor?
+
   $('.pane-splitter')
     .mousedown ->
       draggingSplitter = true
@@ -258,6 +263,7 @@ do ->
       else
         editorStates.preview.openDevTools()
 
+    .on 'setEditorConfig', (editorConfig) -> setEditorConfig editorConfig
     .on 'setSplitter', (spliiterPos) -> setSplitter spliiterPos
     .on 'setTheme', (theme) -> editorStates.updateGlobalSetting '$theme', theme
     .on 'themeChanged', (theme) -> MdsRenderer.sendToMain 'themeChanged', theme

--- a/sass/index.sass
+++ b/sass/index.sass
@@ -12,8 +12,6 @@
     .CodeMirror
       width: 100%
       height: 100%
-      font-family: Osaka-mono, "MS Gothic", monospace
-      font-size: 14px
       line-height: 1.25
 
     .CodeMirror-scroll


### PR DESCRIPTION
Load the editor font and size from the `config.json` file and set it when the browser window is created using an IPC. 

This could potentially improve support for other languages, e.g. #39 and seems may help solve #46.

It could also be used later on to do things like let the user toggle line numbers on/off in the editor

![capture](https://cloud.githubusercontent.com/assets/391950/17641484/b72f2d4c-6165-11e6-83eb-70a8e8f9d1da.PNG)
