### PR TITLE
Implement slide navigation from menus

### DIFF
--- a/coffee/classes/mds_main_menu.coffee
+++ b/coffee/classes/mds_main_menu.coffee
@@ -137,6 +137,19 @@ module.exports = class MdsMainMenu
               accelerator: 'CmdOrCtrl+A'
               click: => @window.mdsWindow.send 'editCommand', 'selectAll' unless @window.mdsWindow.freeze
             }
+            { type: 'separator' }
+            {
+              label: 'Pre&vious Slide'
+              enabled: @window?
+              accelerator: 'Shift+CmdOrCtrl+['
+              click: (i, w) => @window.mdsWindow.send 'jumpSlide', false unless @window.mdsWindow.freeze
+            }
+            {
+              label: '&Next Slide'
+              enabled: @window?
+              accelerator: 'Shift+CmdOrCtrl+]'
+              click: (i, w) => @window.mdsWindow.send 'jumpSlide', true unless @window.mdsWindow.freeze
+            }
           ]
         }
         {

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -34,17 +34,25 @@ class EditorStates
       { label: '&Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' }
       { label: '&Delete', role: 'delete' }
       { label: 'Select &All', accelerator: 'CmdOrCtrl+A', click: (i, w) => @codeMirror.execCommand 'selectAll' if w and !w.mdsWindow.freeze }
+      { type: 'separator' }
+      { label: 'Pre&vious Slide', accelerator: 'CmdOrCtrl+PageUp', click: (i, w) => @navigateSlide(i, w, false) }
+      { label: '&Next Slide', accelerator: 'CmdOrCtrl+PageDown', click: (i, w) => @navigateSlide(i, w, true) }
       { type: 'separator', platform: 'darwin' }
       { label: 'Services', role: 'services', submenu: [], platform: 'darwin' }
     ]
 
-  refreshPage: (rulers) =>
+  getCurrentPage: (rulers) =>
     @rulers = rulers if rulers?
     page    = 1
 
     lineNumber = @codeMirror.getCursor().line || 0
     for rulerLine in @rulers
       page++ if rulerLine <= lineNumber
+
+    page
+
+  refreshPage: (rulers) =>
+    page = @getCurrentPage rulers
 
     if @currentPage != page
       @currentPage = page
@@ -128,6 +136,19 @@ class EditorStates
         "<!-- #{prop}: #{value} -->\n\n",
         CodeMirror.Pos(@codeMirror.firstLine(), 0)
       )
+
+  navigateSlide: (i, w, forward) =>
+    page = @getCurrentPage()
+    return if page == 1 and not forward # can't go "previous from page 1"
+
+    idx = if forward then page - 1 else page - 3
+    idx = if idx > @rulers.length then @rulers.length else idx # prevent overflow
+    editorLine = if idx >= 0 then @rulers[idx] else 0  # prevent underflow
+    console.log "Page #{page}, idx #{idx}, editor line #{editorLine}", @rulers
+
+    @codeMirror.setCursor
+      line: editorLine
+      ch: 0
 
 loadingState = 'loading'
 

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -35,8 +35,8 @@ class EditorStates
       { label: '&Delete', role: 'delete' }
       { label: 'Select &All', accelerator: 'CmdOrCtrl+A', click: (i, w) => @codeMirror.execCommand 'selectAll' if w and !w.mdsWindow.freeze }
       { type: 'separator' }
-      { label: 'Pre&vious Slide', accelerator: 'CmdOrCtrl+PageUp', click: (i, w) => @navigateSlide(i, w, false) }
-      { label: '&Next Slide', accelerator: 'CmdOrCtrl+PageDown', click: (i, w) => @navigateSlide(i, w, true) }
+      { label: 'Pre&vious Slide', accelerator: 'Shift+CmdOrCtrl+[', click: (i, w) => @navigateSlide(i, w, false) }
+      { label: '&Next Slide', accelerator: 'Shift+CmdOrCtrl+]', click: (i, w) => @navigateSlide(i, w, true) }
       { type: 'separator', platform: 'darwin' }
       { label: 'Services', role: 'services', submenu: [], platform: 'darwin' }
     ]
@@ -142,9 +142,8 @@ class EditorStates
     return if page == 1 and not forward # can't go "previous from page 1"
 
     idx = if forward then page - 1 else page - 3
-    idx = if idx > @rulers.length then @rulers.length else idx # prevent overflow
+    idx = if idx >= @rulers.length then @rulers.length - 1 else idx # prevent overflow
     editorLine = if idx >= 0 then @rulers[idx] else 0  # prevent underflow
-    console.log "Page #{page}, idx #{idx}, editor line #{editorLine}", @rulers
 
     @codeMirror.setCursor
       line: editorLine
@@ -272,6 +271,8 @@ do ->
         .filter("[data-viewmode='#{mode}']").addClass('active')
 
     .on 'editCommand', (command) -> editorStates.codeMirror.execCommand(command)
+
+    .on 'jumpSlide', (forwards) -> editorStates.navigateSlide {}, {}, forwards
 
     .on 'openDevTool', ->
       if editorStates.preview.isDevToolsOpened()


### PR DESCRIPTION
Implement navigating between slides using the context menu, re #26. Posting for feedback and some suggestions on how to implement keyboard shortcuts.

At the moment the menu accelerators don't do anything, see https://github.com/electron/electron/issues/2921 which I think is related.

I'll try to add Ctrl+PageUp, Ctrl+PageDown bindings in a second commit.
