### PR TITLE
Update Electron to 1.4.1

### DIFF
--- a/coffee/classes/mds_main_menu.coffee
+++ b/coffee/classes/mds_main_menu.coffee
@@ -123,7 +123,7 @@ module.exports = class MdsMainMenu
             {
               label: '&Redo'
               enabled: @window?
-              accelerator: 'Shift+CmdOrCtrl+Z'
+              accelerator: do -> if /^win/.test(process.platform) then 'Control+Y' else 'Shift+CmdOrCtrl+Z'
               click: => @window.mdsWindow.send 'editCommand', 'redo' unless @window.mdsWindow.freeze
             }
             { type: 'separator' }

--- a/coffee/classes/mds_main_menu.coffee
+++ b/coffee/classes/mds_main_menu.coffee
@@ -123,7 +123,7 @@ module.exports = class MdsMainMenu
             {
               label: '&Redo'
               enabled: @window?
-              accelerator: do -> if /^win/.test(process.platform) then 'Control+Y' else 'Shift+CmdOrCtrl+Z'
+              accelerator: do -> if process.platform is 'win32' then 'Control+Y' else 'Shift+CmdOrCtrl+Z'
               click: => @window.mdsWindow.send 'editCommand', 'redo' unless @window.mdsWindow.freeze
             }
             { type: 'separator' }

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -27,7 +27,11 @@ class EditorStates
 
     @menu = new MdsMenu [
       { label: '&Undo', accelerator: 'CmdOrCtrl+Z', click: (i, w) => @codeMirror.execCommand 'undo' if w and !w.mdsWindow.freeze }
-      { label: '&Redo', accelerator: 'Shift+CmdOrCtrl+Z', click: (i, w) => @codeMirror.execCommand 'redo' if w and !w.mdsWindow.freeze }
+      {
+        label: '&Redo'
+        accelerator: do -> if /^win/.test(process.platform) then 'Control+Y' else 'Shift+CmdOrCtrl+Z'
+        click: (i, w) => @codeMirror.execCommand 'redo' if w and !w.mdsWindow.freeze
+      }
       { type: 'separator' }
       { label: 'Cu&t', accelerator: 'CmdOrCtrl+X', role: 'cut' }
       { label: '&Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' }

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -29,7 +29,7 @@ class EditorStates
       { label: '&Undo', accelerator: 'CmdOrCtrl+Z', click: (i, w) => @codeMirror.execCommand 'undo' if w and !w.mdsWindow.freeze }
       {
         label: '&Redo'
-        accelerator: do -> if /^win/.test(process.platform) then 'Control+Y' else 'Shift+CmdOrCtrl+Z'
+        accelerator: do -> if process.platform is 'win32' then 'Control+Y' else 'Shift+CmdOrCtrl+Z'
         click: (i, w) => @codeMirror.execCommand 'redo' if w and !w.mdsWindow.freeze
       }
       { type: 'separator' }

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -14,7 +14,7 @@ packageOpts =
   dir: 'dist'
   out: 'packages'
   name: config.name
-  version: config.dependencies['electron-prebuilt']
+  version: config.dependencies['electron']
   prune: true
   overwrite: true
   'app-bundle-id': 'jp.yhatt.marp'

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "coffee-script": "^1.10.0",
     "del": "^2.2.0",
+    "electron": "1.4.1",
     "electron-packager": "7.3.0",
-    "electron-prebuilt": "1.2.7",
     "glob": "^7.0.0",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",


### PR DESCRIPTION
This PR will update Electron to 1.4.1, and fix accelator behavior to suit it.

- Rename from `electron-prebuilt` to `electron`.
  - See: http://electron.atom.io/blog/2016/08/16/npm-install-electron  
&nbsp;
- Windows: Use the accelerator `Ctrl+Y` of redo command (to suit Electron 1.4.1)
  - See: https://github.com/electron/electron/pull/7236
  - **NOTE:** _Marp is not using role: `undo`, `redo` and `selectall`_. These role have been found that don't work rightly in CodeMirror.