### PR TITLE
Remove Japanese font definition (Fix #85)

### DIFF
--- a/coffee/classes/mds_config.coffee
+++ b/coffee/classes/mds_config.coffee
@@ -11,7 +11,7 @@ class MdsConfig
 
   @initialConfig:
     editor:
-      fontFamily: 'Osaka-mono, "MS Gothic", monospace'
+      fontFamily: 'Consolas, monaco, monospace'
       fontSize: '14px'
     fileHistory: []
     fileHistoryMax: 8

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "codemirror": "^5.11.0",
     "extend": "^3.0.0",
-    "github-markdown-css": "^2.2.1",
+    "github-markdown-css": "^2.4.1",
     "highlight.js": "^9.1.0",
     "iconv-lite": "^0.4.13",
     "jquery": "^3.0.0",

--- a/sass/themes/default.sass
+++ b/sass/themes/default.sass
@@ -19,11 +19,7 @@
     color: #666
 
   .markdown-body
-    font-family: 'A-OTF UD Shin Go Pro', 'Noto Sans Japanese', 'Kozuka Gothic Pr6N', 'Kozuka Gothic Pro', 'Meiryo UI', 'Meiryo', 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, freesans, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'
     font-size: 29px
-
-    tt, code
-      font-family: 'SourceHanCodeJP-Normal', 'Ricty', Consolas, "Liberation Mono", Menlo, Courier, monospace
 
     h1
       font-size: 1.6em

--- a/sass/themes/gaia.sass
+++ b/sass/themes/gaia.sass
@@ -59,7 +59,7 @@ $highlight-color: #0288d1
 +body-slide-mode
   .markdown-body
     font-size: calc(0.045px * var(--slide-height))
-    font-family: 'Lato', 'Avenir Next', 'Avenir', 'Trebuchet MS', 'Segoe UI', 'Hiragino Kaku Gothic ProN', 'Meiryo', sans-serif
+    font-family: 'Lato', 'Avenir Next', 'Avenir', 'Trebuchet MS', 'Segoe UI', sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"
     line-height: 1.3
     letter-spacing: 1.25px
     word-wrap: break-word
@@ -170,4 +170,3 @@ $highlight-color: #0288d1
 
     &[data-template~="gaia"]
       +color-template($highlight-color, $bg-color, #81d4fa)
-


### PR DESCRIPTION
For internationalize, I removed Japanese fonts from `font-family` definitions on theme / editor. This would fix issue #85.

And the emoji font is specified in theme CSS. Although I do not verify, it might fix #57.