### PR TITLE
Remove gulp's run task, and use npm script to run

### DIFF
--- a/coffee/main.coffee
+++ b/coffee/main.coffee
@@ -15,7 +15,7 @@ global.marp.config.initialize()
 opts =
   file: null
 
-for arg in process.argv.slice(1)
+for arg in process.argv.slice(process.defaultApp ? 2 : 1)
   break_arg = false
   switch arg
     when '--development', '--dev'

--- a/coffee/main.coffee
+++ b/coffee/main.coffee
@@ -15,7 +15,7 @@ global.marp.config.initialize()
 opts =
   file: null
 
-for arg in process.argv.slice(process.defaultApp ? 2 : 1)
+for arg in process.argv.slice(1)
   break_arg = false
   switch arg
     when '--development', '--dev'

--- a/electron.bat
+++ b/electron.bat
@@ -1,4 +1,0 @@
-@echo off
-cd /d %~dp0
-
-./node_modules/.bin/electron.cmd .

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -208,7 +208,3 @@ gulp.task 'archive:linux', (done) ->
   , done
 
 gulp.task 'release', (done) -> runSequence 'build', 'archive', 'clean', done
-
-gulp.task 'run', ['compile'], ->
-  gulp.src '.'
-    .pipe $.runElectron(['--development'])

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "main.js",
   "scripts": {
-    "start": "gulp run",
+    "start": "gulp compile && electron . --development",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -18,7 +18,7 @@
     "coffee-script": "^1.10.0",
     "del": "^2.2.0",
     "electron": "1.4.3",
-    "electron-packager": "7.3.0",
+    "electron-packager": "8.1.0",
     "glob": "^7.0.0",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",
@@ -28,7 +28,6 @@
     "gulp-load-plugins": "^1.2.0",
     "gulp-plist": "^0.1.0",
     "gulp-plumber": "^1.0.1",
-    "gulp-run-electron": "^2.0.0",
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tar": "^1.8.0",


### PR DESCRIPTION
`gulp-run-electron` is dependent to `electron-prebuilt`. But it is already obsoleted (See #91) and it would not work correctly in WIndows.

This PR will use npm script for running electron.