### PR TITLE
Fix #104: Avoid app termination unexpectedly on Linux

### DIFF
--- a/coffee/classes/mds_window.coffee
+++ b/coffee/classes/mds_window.coffee
@@ -87,16 +87,10 @@ module.exports = class MdsWindow
             detail: "#{@getShortPath()} has been modified. Do you want to save the changes?"
             cancelId: 2
           , (result) =>
+            # Wrap by setTimeout to avoid app termination unexpectedly on Linux.
             switch result
-              when 0
-                # Wrap by setTimeout to avoid app termination unexpectedly on Linux.
-                setTimeout =>
-                  @trigger 'save', 'forceClose'
-                , 0
-              when 1
-                setTimeout =>
-                  @trigger 'forceClose'
-                , 0
+              when 0 then setTimeout (=> @trigger 'save', 'forceClose'), 0
+              when 1 then setTimeout (=> @trigger 'forceClose'), 0
               else
                 MdsWindow.appWillQuit = false
 

--- a/coffee/classes/mds_window.coffee
+++ b/coffee/classes/mds_window.coffee
@@ -85,10 +85,18 @@ module.exports = class MdsWindow
             title: 'Marp'
             message: 'Are you sure?'
             detail: "#{@getShortPath()} has been modified. Do you want to save the changes?"
+            cancelId: 2
           , (result) =>
             switch result
-              when 0 then @trigger 'save', 'forceClose'
-              when 1 then @trigger 'forceClose'
+              when 0
+                # Wrap by setTimeout to avoid app termination unexpectedly on Linux.
+                setTimeout =>
+                  @trigger 'save', 'forceClose'
+                , 0
+              when 1
+                setTimeout =>
+                  @trigger 'forceClose'
+                , 0
               else
                 MdsWindow.appWillQuit = false
 


### PR DESCRIPTION
This PR would fix #104.

`BrowserWindow.destory()` in `dialog` callback function will terminate app unexpectedly on Linux. So it became to call it on main thread by using `setTimeout(func, 0)`

### Fixes

- Wrap triggers of internal command with setTimeout
- Set cancelId as "Cancel" command (Fix behavior of `Esc` key)