### PR TITLE
Fix building electron version

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -14,7 +14,7 @@ packageOpts =
   dir: 'dist'
   out: 'packages'
   name: config.name
-  version: config.dependencies['electron']
+  version: config.devDependencies['electron']
   prune: true
   overwrite: true
   'app-bundle-id': 'jp.yhatt.marp'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "coffee-script": "^1.10.0",
     "del": "^2.2.0",
-    "electron": "1.4.3",
+    "electron": "1.3.8",
     "electron-packager": "8.1.0",
     "glob": "^7.0.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
`gulpfile.coffee` has a wrong way to get the version of Electron.

And update to latest version of Electron 1.3.8. This contains rollback to 1.3.x for to fix #101 temporarily.