### PR TITLE
Enable `ignore_illegals` in `highlightJs.highlight` invokation

### DIFF
--- a/coffee/classes/mds_markdown.coffee
+++ b/coffee/classes/mds_markdown.coffee
@@ -16,7 +16,7 @@ module.exports = class MdsMarkdown
         return ''
       else if highlightJs.getLanguage(lang)
         try
-          return highlightJs.highlight(lang, code).value
+          return highlightJs.highlight(lang, code, true).value
 
     highlightJs.highlightAuto(code).value
 


### PR DESCRIPTION
Works around the issues mentioned in #132. Modern C++ code like

```cpp
template <typename A, typename B>
auto add(A a, B b) -> decltype(a + b)
{
    return a + b;
}
```

is highlighted correctly! :)