### PR TITLE
Add simple presentation mode

### DIFF
--- a/coffee/classes/mds_main_menu.coffee
+++ b/coffee/classes/mds_main_menu.coffee
@@ -158,6 +158,24 @@ module.exports = class MdsMainMenu
               accelerator: do -> if process.platform == 'darwin' then 'Ctrl+Command+F' else 'F11'
               role: 'togglefullscreen'
             }
+            { type: 'separator' }
+            {
+              label: 'Pre&vious Slide'
+              enabled: @window?
+              accelerator: 'CmdOrCtrl+Up'
+              click: (i, w) => @window.mdsWindow.send 'jumpSlide', false unless @window.mdsWindow.freeze
+            }
+            {
+              label: '&Next Slide'
+              enabled: @window?
+              accelerator: 'CmdOrCtrl+Down'
+              click: (i, w) => @window.mdsWindow.send 'jumpSlide', true unless @window.mdsWindow.freeze
+            }
+            {
+              label: '&Start Presentation'
+              click: =>
+                @window.mdsWindow.send 'startPresentation'
+            }
           ]
         }
         {

--- a/coffee/classes/mds_window.coffee
+++ b/coffee/classes/mds_window.coffee
@@ -58,6 +58,7 @@ module.exports = class MdsWindow
         window: bw
         development: global.marp.development
         viewMode: @viewMode
+        presentationMode: false
 
       bw.maximize() if global.marp.config.get 'windowPosition.maximized'
 
@@ -234,7 +235,14 @@ module.exports = class MdsWindow
       @menu.updateMenu()
 
     startPresentation: ->
+      @menu.states.presentationMode = true
       @browserWindow.setFullScreen(true)
+
+    exitPresentation: ->
+      if @menu.states.presentationMode
+        @menu.states.presentationMode = false
+        @browserWindow.setFullScreen(false)
+        @send 'exitPresentation'
 
     unfreeze: ->
       @freeze = false

--- a/coffee/classes/mds_window.coffee
+++ b/coffee/classes/mds_window.coffee
@@ -244,6 +244,10 @@ module.exports = class MdsWindow
         @browserWindow.setFullScreen(false)
         @send 'exitPresentation'
 
+    jumpSlide: (forwards) ->
+      if @menu.states.presentationMode
+        @send 'jumpSlide', forwards
+
     unfreeze: ->
       @freeze = false
       @send 'unfreezed'

--- a/coffee/classes/mds_window.coffee
+++ b/coffee/classes/mds_window.coffee
@@ -233,6 +233,9 @@ module.exports = class MdsWindow
       @menu.states.theme = theme
       @menu.updateMenu()
 
+    startPresentation: ->
+      @browserWindow.setFullScreen(true)
+
     unfreeze: ->
       @freeze = false
       @send 'unfreezed'
@@ -249,7 +252,7 @@ module.exports = class MdsWindow
     return '(untitled)' unless @path?
     @path.replace(/\\/g, '/').replace(/.*\//, '')
 
-  getCurrentFile: => 
+  getCurrentFile: =>
     return 'untitled' unless @path?
     @path.replace(/\\/g, '/').replace(/.*\//, '').replace(/\.[^/.]+$/, "")
 

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -167,6 +167,19 @@ do ->
   # View modes
   $('.viewmode-btn[data-viewmode]').click -> MdsRenderer.sendToMain('viewMode', $(this).attr('data-viewmode'))
 
+  $('.pane.preview').keydown (event) ->
+    forwards = switch event.which
+      when 13 # enter key
+        true
+      when 39 # right key
+        true
+      when 37 # left key
+        false
+      else
+        null
+    if forwards != null
+      editorStates.navigateSlide {}, {}, forwards
+
   # File D&D
   $(document)
     .on 'dragover',  -> false

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -38,17 +38,21 @@ class EditorStates
       { label: '&Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' }
       { label: '&Delete', role: 'delete' }
       { label: 'Select &All', accelerator: 'CmdOrCtrl+A', click: (i, w) => @codeMirror.execCommand 'selectAll' if w and !w.mdsWindow.freeze }
-      { type: 'separator', platform: 'darwin' }
       { label: 'Services', role: 'services', submenu: [], platform: 'darwin' }
     ]
 
-  refreshPage: (rulers) =>
+  getCurrentPage: (rulers) =>
     @rulers = rulers if rulers?
     page    = 1
 
     lineNumber = @codeMirror.getCursor().line || 0
     for rulerLine in @rulers
       page++ if rulerLine <= lineNumber
+
+    page
+
+  refreshPage: (rulers) =>
+    page = @getCurrentPage rulers
 
     if @currentPage != page
       @currentPage = page
@@ -133,6 +137,17 @@ class EditorStates
         CodeMirror.Pos(@codeMirror.firstLine(), 0)
       )
 
+  navigateSlide: (i, w, forward) =>
+    page = @getCurrentPage()
+    return if page == 1 and not forward # can't go "previous from page 1"
+
+    idx = if forward then page - 1 else page - 3
+    idx = if idx >= @rulers.length then @rulers.length - 1 else idx # prevent overflow
+    editorLine = if idx >= 0 then @rulers[idx] else 0  # prevent underflow
+    @codeMirror.setCursor
+      line: editorLine
+      ch: 0
+
 loadingState = 'loading'
 
 do ->
@@ -172,7 +187,12 @@ do ->
   draggingSplitPosition = undefined
 
   setSplitter = (splitPoint) ->
-    splitPoint = Math.min(0.8, Math.max(0.2, parseFloat(splitPoint)))
+    min_allowed = 0.2
+
+    if splitPoint < 0.01
+      min_allowed = 0.0
+
+    splitPoint = Math.min(0.8, Math.max(min_allowed, parseFloat(splitPoint)))
 
     $('.pane.markdown').css('flex-grow', splitPoint * 100)
     $('.pane.preview').css('flex-grow', (1 - splitPoint) * 100)
@@ -272,6 +292,13 @@ do ->
     .on 'setTheme', (theme) -> editorStates.updateGlobalSetting '$theme', theme
     .on 'themeChanged', (theme) -> MdsRenderer.sendToMain 'themeChanged', theme
     .on 'resourceState', (state) -> loadingState = state
+
+    .on 'startPresentation', ->
+      $('#md-pane').addClass('presentation')
+      $('#footer').addClass('presentation')
+      MdsRenderer.sendToMain 'startPresentation'
+
+    .on 'jumpSlide', (forwards) -> editorStates.navigateSlide {}, {}, forwards
 
   # Initialize
   editorStates.codeMirror.focus()

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -167,22 +167,25 @@ do ->
   # View modes
   $('.viewmode-btn[data-viewmode]').click -> MdsRenderer.sendToMain('viewMode', $(this).attr('data-viewmode'))
 
-  $('.pane.preview').keydown (event) ->
-    console.log(event)
+  $('body').keydown (event) ->
     forwards = switch event.which
       when 13 # enter
         true
+      when 38 # up
+        false
       when 39 # right
         true
       when 37 # left
         false
+      when 40 # down
+        true
       when 27 # escape
         MdsRenderer.sendToMain('exitPresentation')
         null
       else
         null
     if forwards != null
-      editorStates.navigateSlide {}, {}, forwards
+      MdsRenderer.sendToMain('jumpSlide', forwards)
 
   # File D&D
   $(document)

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -168,13 +168,17 @@ do ->
   $('.viewmode-btn[data-viewmode]').click -> MdsRenderer.sendToMain('viewMode', $(this).attr('data-viewmode'))
 
   $('.pane.preview').keydown (event) ->
+    console.log(event)
     forwards = switch event.which
-      when 13 # enter key
+      when 13 # enter
         true
-      when 39 # right key
+      when 39 # right
         true
-      when 37 # left key
+      when 37 # left
         false
+      when 27 # escape
+        MdsRenderer.sendToMain('exitPresentation')
+        null
       else
         null
     if forwards != null
@@ -307,9 +311,14 @@ do ->
     .on 'resourceState', (state) -> loadingState = state
 
     .on 'startPresentation', ->
+      new Notification('Press escape key to exit presentation mode.')
       $('#md-pane').addClass('presentation')
       $('#footer').addClass('presentation')
       MdsRenderer.sendToMain 'startPresentation'
+
+    .on 'exitPresentation', ->
+      $('#md-pane').removeClass('presentation')
+      $('#footer').removeClass('presentation')
 
     .on 'jumpSlide', (forwards) -> editorStates.navigateSlide {}, {}, forwards
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <div class="window">
       <div class="window-content">
         <div class="pane-group">
-          <div class="pane markdown">
+          <div class="pane markdown" id="md-pane">
             <textarea id="editor" wrap="soft"></textarea>
             <div class="pane-splitter left"></div>
           </div>
@@ -25,7 +25,7 @@
           </div>
         </div>
       </div>
-      <footer class="toolbar toolbar-footer">
+      <footer class="toolbar toolbar-footer" id="footer">
         <div class="toolbar-actions">
           <span id="page-indicator"></span>
           <div class="btn-group pull-right disabled" id="preview-modes">

--- a/sass/index.sass
+++ b/sass/index.sass
@@ -125,3 +125,6 @@ body.exporting-pdf
 
   #exporting-indicator
     display: block
+
+.presentation
+  display: none


### PR DESCRIPTION
I implemented simple presentation mode. To start presentation mode, select `View` -> `Start Presentation` on menu. On presentation mode, you can jump slide on up, down, right, left and enter key. To press escape key, presentation mode will exit.

I used some code from #154 for jumping next/previous page.

ref #13 