### PR TITLE
build(gulp): watch for modifications to restart app

### DIFF
--- a/coffee/classes/mds_window.coffee
+++ b/coffee/classes/mds_window.coffee
@@ -9,6 +9,7 @@ fs             = require 'fs'
 jschardet      = require 'jschardet'
 iconv_lite     = require 'iconv-lite'
 Path           = require 'path'
+electronClient = require('electron-connect').client
 
 module.exports = class MdsWindow
   @appWillQuit: false
@@ -58,6 +59,13 @@ module.exports = class MdsWindow
         window: bw
         development: global.marp.development
         viewMode: @viewMode
+
+      electronClient.create(bw)
+
+      if global.marp.development
+        bw.setAlwaysOnTop(true)
+        bw.focus()
+        bw.setAlwaysOnTop(false)
 
       bw.maximize() if global.marp.config.get 'windowPosition.maximized'
 

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -8,6 +8,7 @@ runSequence = require('run-sequence')
 Path        = require('path')
 extend      = require('extend')
 mkdirp      = require('mkdirp')
+electron    = require('electron-connect').server.create({ stopOnClose: true })
 
 packageOpts =
   asar: true
@@ -208,3 +209,14 @@ gulp.task 'archive:linux', (done) ->
   , done
 
 gulp.task 'release', (done) -> runSequence 'build', 'archive', 'clean', done
+
+gulp.task 'dev', ['compile'], () ->
+  electron.start "--development", (state) ->
+    process.exit(0) if state == 'stopped'
+
+  gulp.watch [
+    'coffee/**/*.coffee',
+    'sass/**/*.scss',
+    'sass/**/*.sass'
+  ]
+  , ['compile', electron.restart]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "main.js",
   "scripts": {
-    "start": "gulp compile && electron . --development",
+    "start": "gulp dev",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "codemirror": "^5.11.0",
+    "electron-connect": "^0.6.2",
     "extend": "^3.0.0",
     "github-markdown-css": "^2.4.1",
     "highlight.js": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,6 +175,10 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 async@^2.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.4.1.tgz#62a56b279c98a11d0987096a01cc3eeb8eb7bbd7"
@@ -549,6 +553,14 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -742,6 +754,15 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+electron-connect@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/electron-connect/-/electron-connect-0.6.2.tgz#83dc042ef26e2b6b3e1d0f44ec89ec4140646bc3"
+  dependencies:
+    cross-spawn "^5.1.0"
+    lodash "^4.17.4"
+    tree-kill "^1.1.0"
+    ws "^3.1.0"
 
 electron-download@^3.0.0, electron-download@^3.0.1:
   version "3.3.0"
@@ -2031,7 +2052,7 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.8.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3055,6 +3076,16 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -3344,6 +3375,10 @@ tough-cookie@~2.3.0:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
 
+tree-kill@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.0.tgz#5846786237b4239014f05db156b643212d4c6f36"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -3392,6 +3427,10 @@ uglify-save-license@^0.4.1:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+ultron@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"
@@ -3554,6 +3593,14 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+ws@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.2.0.tgz#d5d3d6b11aff71e73f808f40cc69d52bb6d4a185"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
 
 xmlbuilder@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Now it's easier to develop Marp. Just run `gulp dev` or `npm start` (same thing) and it will automatically **recompile** then **restart** app when `.coffee` or `.sass`/`.scss` files are modified. 

Also:
* it recognizes when we close window by hand, then gulp watch is stopped (`process.exit(0)`)
* when we kill gulp watch process then window is closed too (`electronClient`)
* while development we edit code files so app window has to be brought to top (`bw.focus()`)

Side note: Recommended to install with `yarn` since there is `yarn.lock`. Just yesterday I had no luck with `npm i` due to some related to `twemoji`.