### PR TITLE
[Security update] 0.0.13

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-PATH_add node_modules/.bin

--- a/coffee/classes/mds_markdown.coffee
+++ b/coffee/classes/mds_markdown.coffee
@@ -48,8 +48,8 @@ module.exports = class MdsMarkdown
     (md) ->
       mdElm = $("<div>#{md.parsed}</div>")
 
-      # Sanitize HTML import
-      mdElm.find('link[rel="import"]').remove()
+      # Sanitize link tag
+      mdElm.find('link:not([rel="stylesheet"])').remove()
 
       mdElm.find('p > img[alt~="bg"]').each ->
         $t  = $(@)

--- a/gulp.bat
+++ b/gulp.bat
@@ -1,5 +1,0 @@
-@echo off
-cd /d %~dp0
-
-shift
-./node_modules/.bin/gulp.cmd %*

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -15,8 +15,7 @@ packageOpts =
   out: 'packages'
   name: config.productName
   version: config.devDependencies['electron']
-  prune: true
-  packageManager: 'yarn'
+  prune: false
   overwrite: true
   'app-bundle-id': 'jp.yhatt.marp'
   'app-version': config.version
@@ -115,7 +114,7 @@ gulp.task 'dist', ['clean:dist'], ->
     .pipe $.install
       commands:
         'package.json': 'yarn'
-      yarn: ['--production']
+      yarn: ['--production', '--ignore-optional', '--no-bin-links']
 
 gulp.task 'package', ['clean:packages', 'dist'], (done) ->
   runSequence 'package:win32', 'package:darwin', 'package:linux', done
@@ -172,7 +171,7 @@ gulp.task 'archive:darwin', (done) ->
     null
 
   unless appdmg
-    $.util.log 'Archiving for darwin is supported only OSX.'
+    $.util.log 'Archiving for darwin is supported only macOS.'
     return done()
 
   globFolders 'packages/*-darwin-*', (path, globDone) ->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marp",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "description": "Markdown Presentation Writer (Powered by Electron)",
   "productName": "Marp",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "author": "Yuki Hattori",
   "license": "MIT",
   "devDependencies": {
-    "appdmg": "^0.5.2",
     "coffee-script": "^1.10.0",
     "del": "^3.0.0",
     "electron": "1.8.4",
@@ -54,5 +53,8 @@
     "path": "^0.12.7",
     "photon": "github:connors/photon",
     "twemoji": "^2.5.1"
+  },
+  "optionalDependencies": {
+    "appdmg": "^0.5.2"
   }
 }

--- a/slide.html
+++ b/slide.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="connect-src http: https:; child-src http: https:;" />
+    <meta http-equiv="Content-Security-Policy" content="connect-src http: https:; child-src http: https:; script-src http: https: 'unsafe-inline';" />
 
     <title>Marp presentation</title>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -397,24 +397,24 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
-buffer-alloc-unsafe@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz#ffe1f67551dd055737de253337bfe853dfab1a6a"
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
 
 buffer-alloc@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.1.0.tgz#05514d33bf1656d3540c684f65b1202e90eca303"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
   dependencies:
-    buffer-alloc-unsafe "^0.1.0"
-    buffer-fill "^0.1.0"
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
 
 buffer-crc32@^0.2.1, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
-buffer-fill@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-0.1.1.tgz#76d825c4d6e50e06b7a31eb520c04d08cc235071"
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^0.1.1:
   version "0.1.2"
@@ -2380,8 +2380,8 @@ lru-cache@2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
 lru-cache@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -3390,7 +3390,7 @@ readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.0.6, readable
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.1, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.3.5:
+readable-stream@^2.0.1, readable-stream@^2.1.5, readable-stream@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
@@ -3400,6 +3400,18 @@ readable-stream@^2.0.1, readable-stream@^2.1.4, readable-stream@^2.1.5, readable
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.1.4:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 rechoir@^0.6.2:
@@ -3749,6 +3761,12 @@ string_decoder@~0.10.x:
 string_decoder@~1.0.0, string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -4126,9 +4144,15 @@ which@1, which@^1.2.12, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@^1.2.14, which@^1.2.8:
+which@^1.2.14:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.8:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
This is a security update caused by a mention of https://github.com/yhatt/marp/issues/187#issuecomment-396781598.

We have recognized that v0.0.12 still has a remaining way to be able accessing to the content of the local resource ([CVE-2017-2239](https://nvd.nist.gov/vuln/detail/CVE-2017-2239)). We are setting CSP for scripts to minimize exploit.

This update will affect a few expert users using the external local script in Markdown (e.g. Chart rendering), but this change has limited impact.

### In future

For security, we are planning [the next-gen Marp](https://github.com/marp-team/marp) will limit execution of *any* scripts.

> To migrate to next-gen marp, we are not planning of minor upgrade / additional features for current Marp.